### PR TITLE
Upgrade DarkRadiant to 3.5.0

### DIFF
--- a/8b5bfc8a23f8e60beb83bfebdf2c3026baf10269.patch
+++ b/8b5bfc8a23f8e60beb83bfebdf2c3026baf10269.patch
@@ -1,0 +1,21 @@
+From 8b5bfc8a23f8e60beb83bfebdf2c3026baf10269 Mon Sep 17 00:00:00 2001
+From: codereader <greebo@angua.at>
+Date: Fri, 28 Oct 2022 14:33:27 +0200
+Subject: [PATCH] Fix missing MediaBrowser module in Linux
+
+---
+ radiant/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/radiant/CMakeLists.txt b/radiant/CMakeLists.txt
+index 4ab172034..04c9c64f6 100644
+--- a/radiant/CMakeLists.txt
++++ b/radiant/CMakeLists.txt
+@@ -120,6 +120,7 @@ add_executable(darkradiant
+                ui/mapinfo/ShaderInfoTab.cpp
+                ui/mediabrowser/MediaBrowser.cpp
+                ui/mediabrowser/MediaBrowserTreeView.cpp
++               ui/mediabrowser/MediaBrowserModule.cpp
+                ui/modelexport/ConvertModelDialog.cpp
+                ui/modelexport/ExportAsModelDialog.cpp
+                ui/modelexport/ExportCollisionModelDialog.cpp

--- a/94d61d951e72aa93aa0a5bc068281cdb08669397.patch
+++ b/94d61d951e72aa93aa0a5bc068281cdb08669397.patch
@@ -1,0 +1,21 @@
+From 94d61d951e72aa93aa0a5bc068281cdb08669397 Mon Sep 17 00:00:00 2001
+From: jonri <jonri@users.noreply.github.com>
+Date: Fri, 28 Oct 2022 11:04:17 -0400
+Subject: [PATCH] Add 3.5.0 release information to metainfo
+
+---
+ install/net.darkradiant.DarkRadiant.metainfo.xml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/install/net.darkradiant.DarkRadiant.metainfo.xml b/install/net.darkradiant.DarkRadiant.metainfo.xml
+index 41419db01..758ce5886 100644
+--- a/install/net.darkradiant.DarkRadiant.metainfo.xml
++++ b/install/net.darkradiant.DarkRadiant.metainfo.xml
+@@ -69,6 +69,7 @@
+   <launchable type="desktop-id">net.darkradiant.DarkRadiant.desktop</launchable>
+ 
+   <releases>
++    <release version="3.5.0" date="2022-10-28"/>
+     <release version="3.4.0" date="2022-10-09"/>
+     <release version="3.3.0" date="2022-09-23"/>
+     <release version="3.2.0" date="2022-09-03"/>

--- a/net.darkradiant.DarkRadiant.yml
+++ b/net.darkradiant.DarkRadiant.yml
@@ -55,6 +55,10 @@ modules:
   - name: darkradiant
     buildsystem: cmake-ninja
     sources:
-      - type: git
-        url: https://github.com/codereader/DarkRadiant.git
-        commit: bd348305042b225906da3324499b54d8be7f6ba7
+      - type: archive
+        url: https://github.com/codereader/DarkRadiant/archive/refs/tags/3.5.0.tar.gz
+        sha256: a5a5e87f607779976a5b5c98bf51a1fa9ca254d4bbbdae7f572865c85dd0a7d8
+      - type: patch
+        path: 8b5bfc8a23f8e60beb83bfebdf2c3026baf10269.patch
+      - type: patch
+        path: 94d61d951e72aa93aa0a5bc068281cdb08669397.patch


### PR DESCRIPTION
Builds from the tagged release plus cherry-picked commits with build/version fixes